### PR TITLE
Add notes about compatibility and default key to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Outguess is an advanced steganography tool for mac. Outguess will conceal your d
  <img src="https://www.rbcafe.com/wp-content/uploads/outguess-explain.png" alt="Outguess" width="596">
 </p>
 
+## Compatibility and default key
+
+- Compatible with version >= 0.2 of `outguess` console tool.
+- Use key `Default key` to get a "without a key" behaviour.
+
 ## More information 
 
 https://www.rbcafe.com/software/outguess/


### PR DESCRIPTION
Original tool can be used without explicit key, when not set - key is `Default key`

Also it's better to note, that different versions of original tool are not compatible (0.2 had breaking changes)